### PR TITLE
Change api: don't store main context in Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Package workerctl is controller of application's initialization and its graceful
 
 ## Usage
 ```go
+package main
+
 import (
 	"context"
 	"log"
@@ -20,7 +22,7 @@ import (
 func main() {
 	ctx := context.Background()
 	a := &workerctl.Aborter{}
-	ctl, shutdown := workerctl.New(ctx)
+	ctl, shutdown := workerctl.New()
 
 	a.AbortOnError(func() (err error) {
 		// 1. Init shared resource and bind to this Controller.
@@ -35,7 +37,7 @@ func main() {
 		oneShot := &OneShotTaskRunner{
 			Writer: logOutput,
 		}
-		err = ctl.Launch(oneShot)
+		err = ctl.Launch(ctx, oneShot)
 		if err != nil {
 			return err
 		}
@@ -48,7 +50,7 @@ func main() {
 				OneShot: oneShot,
 				Writer:  logOutput,
 			}
-			err := ctl.Launch(server)
+			err := ctl.Launch(ctx, server)
 			if err != nil {
 				return err
 			}

--- a/control.go
+++ b/control.go
@@ -4,11 +4,9 @@ package workerctl
 
 import (
 	"context"
+	"errors"
 	"io"
 	"sync"
-	"time"
-
-	"github.com/daichitakahashi/oncewait"
 )
 
 type (
@@ -25,24 +23,16 @@ type (
 		// Launch registers WorkerLauncher to this Controller and call it.
 		// Return error when LaunchWorker cause error.
 		// Failure of Launch makes no side effect on Controller's state.
-		Launch(l WorkerLauncher) error
+		Launch(ctx context.Context, l WorkerLauncher) error
 
-		// Bind resource to Controller.
+		// Bind resources to Controller.
 		// After completion of controller's shutdown, resources will be closed.
-		Bind(rc io.Closer)
-
-		// Context returns Controller's Context.
-		Context() context.Context
-
-		// WithContext returns a Controller with its context changed to ctx.
-		// The provided ctx must be non-nil.
-		// It's assumed to set values to context with context.WithValue.
-		WithContext(ctx context.Context) Controller
+		Bind(rcs ...io.Closer)
 	}
 
 	// ShutdownFunc is a return value of New. It shuts down created Controller.
 	// Parameter ctx will be passed to shutdown functions of each worker, so we can set timeout using context.WithDeadline or context.WithTimeout.
-	// It's assumed tobe used in combination with configuration of container shutdown.
+	// It is assumed to be used in combination with configuration of container shutdown.
 	// For example, `docker stop --timeout` or task definition parameter `stopTimeout` on AWS ECS.
 	ShutdownFunc func(ctx context.Context) error
 
@@ -65,50 +55,44 @@ func (f Func) LaunchWorker(ctx context.Context) (stop func(ctx context.Context),
 // A root Controller.
 type root struct {
 	*controller
-	shutdownCtx    context.Context
-	cancelShutdown context.CancelFunc
-	shutdownOnce   *oncewait.OnceWaiter
+	hook        chan struct{}
+	shutdownCtx context.Context
 }
 
 // New returns a new Controller which scope is bound to ctx and ShutdownFunc.
 // When ctx canceled, Controller starts shutdown. Also calling ShutdownFunc does the same.
 // However, cancellation of context.Context cannot set Context of shutdown.
 // If you need, use WithDefaultShutdownContext to ctx before New.
-func New(ctx context.Context) (Controller, ShutdownFunc) {
-	parentCtx, cancel := context.WithCancel(ctx)
+func New() (Controller, ShutdownFunc) {
+	hook := make(chan struct{})
 	r := &root{
-		shutdownOnce: oncewait.New(),
+		hook: hook,
 	}
 	r.controller = &controller{
-		root:       r,
-		ctx:        parentCtx,
-		dependents: &sync.WaitGroup{},
-		workers:    &sync.WaitGroup{},
-		shutdown:   make(chan struct{}),
+		root:     r,
+		shutdown: make(chan struct{}),
 	}
 
-	// trap cancellation of Context or calling ShutdownFunc.
+	// trap calling ShutdownFunc
 	done := make(chan struct{})
 	go func() {
-		<-parentCtx.Done()
+		<-hook
 		r.wait()
 		close(done)
 		return
 	}()
 
 	return r, func(ctx context.Context) error {
-		// determine shutdown context.
-		shutdownCtx, cancelShutdown := r.determineShutdownContext(ctx)
-		defer cancelShutdown()
+		// set shutdown context
+		r.shutdownCtx = ctx
 
-		// cancel main context.
-		cancel()
+		// hook cancellation
+		close(hook)
 
 		select {
-		case <-shutdownCtx.Done():
-			return shutdownCtx.Err()
-		case <-parentCtx.Done():
-			<-done
+		case <-r.shutdownCtx.Done():
+			return r.shutdownCtx.Err()
+		case <-done:
 		}
 		return nil
 	}
@@ -117,28 +101,8 @@ func New(ctx context.Context) (Controller, ShutdownFunc) {
 type key int8
 
 const (
-	defaultShutdownKey key = iota + 1
-	abortKey
+	abortKey key = iota + 1
 )
-
-// WithDefaultShutdownContext returns copy of parent which has a value of newShutdownCtx.
-// When Controller starts shutdown, if shutdown context is not specified, Controller calls newShutdownCtx and use return value as shutdown Context.
-// It is intended to be used when starting shutdown by canceling Context.
-func WithDefaultShutdownContext(ctx context.Context, newShutdownCtx func(ctx context.Context) context.Context) context.Context {
-	return context.WithValue(ctx, defaultShutdownKey, func(ctx context.Context) (context.Context, context.CancelFunc) {
-		return newShutdownCtx(ctx), func() {}
-	})
-}
-
-// WithDefaultShutdownTimeout is a shorthand of
-//	WithDefaultShutdownContext(ctx, func(ctx context.Context) context.Context {
-//		return context.WithTimeout(ctx, timeout)
-//	})
-func WithDefaultShutdownTimeout(ctx context.Context, timeout time.Duration) context.Context {
-	return context.WithValue(ctx, defaultShutdownKey, func(ctx context.Context) (context.Context, context.CancelFunc) {
-		return context.WithTimeout(ctx, timeout)
-	})
-}
 
 // WithAbort set Aborter to new Context based on ctx.
 // Call Abort with returned new Context, set Aborter's Abort is called.
@@ -149,41 +113,15 @@ func WithAbort(ctx context.Context, a *Aborter) context.Context {
 // Abort invoke Aborter.Abort set by using WithAbort.
 // Workers can signal abort if they know Controller's context.
 func Abort(ctx context.Context) {
-	v := ctx.Value(abortKey)
-	if v != nil {
-		v.(*Aborter).Abort()
-	}
-}
-
-// Determine context of shutdown.
-// When ShutdownFunc is called, parameter 'ctx' is used.
-// However, when context of root Controller is canceled, we have no context, so we have to determine shutdown context.
-// Unless WithDefaultShutdownContext or WithDefaultShutdownTimeout is set, context.Background() is used.
-func (r *root) determineShutdownContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	r.shutdownOnce.Do(func() {
-		if ctx != nil {
-			r.shutdownCtx = ctx
-			r.cancelShutdown = func() {}
-		} else {
-			v := r.ctx.Value(defaultShutdownKey)
-			if newShutdownCtx, ok := v.(func(context.Context) (context.Context, context.CancelFunc)); ok {
-				r.shutdownCtx, r.cancelShutdown = newShutdownCtx(context.Background())
-			} else {
-				r.shutdownCtx = context.Background()
-				r.cancelShutdown = func() {}
-			}
-		}
-	})
-	return r.shutdownCtx, r.cancelShutdown
+	ctx.Value(abortKey).(*Aborter).Abort()
 }
 
 var _ Controller = (*root)(nil)
 
 type controller struct {
 	root       *root
-	ctx        context.Context
-	dependents *sync.WaitGroup
-	workers    *sync.WaitGroup
+	dependents sync.WaitGroup
+	workers    sync.WaitGroup
 	shutdown   chan struct{}
 	rcs        Closer
 	m          sync.Mutex
@@ -203,18 +141,18 @@ func (c *controller) wait() {
 }
 
 // Launch launches worker, and set trap to catch signal of shutdown.
-func (c *controller) Launch(l WorkerLauncher) error {
+func (c *controller) Launch(ctx context.Context, l WorkerLauncher) error {
 	c.m.Lock()
 	defer c.m.Unlock()
 
 	// prevent launch after shutdown.
 	select {
-	case <-c.ctx.Done():
-		return c.ctx.Err()
+	case <-c.root.hook:
+		return errors.New("shutdown already started")
 	default:
 	}
 
-	stop, err := l.LaunchWorker(c.ctx)
+	stop, err := l.LaunchWorker(ctx)
 	if err != nil {
 		return err
 	}
@@ -223,9 +161,7 @@ func (c *controller) Launch(l WorkerLauncher) error {
 	go func() {
 		defer c.workers.Done()
 		<-c.shutdown
-
-		ctx, _ := c.root.determineShutdownContext(nil)
-		stop(ctx)
+		stop(c.root.shutdownCtx)
 		return
 	}()
 	return nil
@@ -234,42 +170,23 @@ func (c *controller) Launch(l WorkerLauncher) error {
 // Dependent creates dependent Controller, and set trap to catch signal of shutdown.
 func (c *controller) Dependent() Controller {
 	dependent := &controller{
-		root:       c.root,
-		ctx:        c.ctx,
-		dependents: &sync.WaitGroup{},
-		workers:    &sync.WaitGroup{},
-		shutdown:   make(chan struct{}),
+		root:     c.root,
+		shutdown: make(chan struct{}),
 	}
 	c.dependents.Add(1)
 	go func() {
 		defer c.dependents.Done()
-		select {
-		case <-c.ctx.Done():
-			dependent.wait()
-		}
+		<-c.root.hook
+		dependent.wait()
 		return
 	}()
 	return dependent
 }
 
-func (c *controller) Bind(rc io.Closer) {
+func (c *controller) Bind(rcs ...io.Closer) {
 	c.m.Lock()
 	defer c.m.Unlock()
-	c.rcs = append(c.rcs, rc)
-}
-
-func (c *controller) Context() context.Context {
-	return c.ctx
-}
-
-func (c *controller) WithContext(ctx context.Context) Controller {
-	return &controller{
-		root:       c.root,
-		ctx:        ctx,
-		dependents: c.dependents,
-		workers:    c.workers,
-		rcs:        c.rcs,
-	}
+	c.rcs = append(c.rcs, rcs...)
 }
 
 var _ Controller = (*controller)(nil)

--- a/example/main.go
+++ b/example/main.go
@@ -16,7 +16,7 @@ func main() {
 	a := &workerctl.Aborter{}
 	ctx = workerctl.WithAbort(ctx, a)
 
-	ctl, shutdown := workerctl.New(ctx)
+	ctl, shutdown := workerctl.New()
 
 	a.AbortOnError(func() (err error) {
 		// 1. Init shared resource and bind to this Controller.
@@ -31,7 +31,7 @@ func main() {
 		oneShot := &OneShotTaskRunner{
 			Writer: logOutput,
 		}
-		err = ctl.Launch(oneShot)
+		err = ctl.Launch(ctx, oneShot)
 		if err != nil {
 			return err
 		}
@@ -44,7 +44,7 @@ func main() {
 				OneShot: oneShot,
 				Writer:  logOutput,
 			}
-			err := ctl.Launch(server)
+			err := ctl.Launch(ctx, server)
 			if err != nil {
 				return err
 			}

--- a/job_test.go
+++ b/job_test.go
@@ -1,14 +1,16 @@
-package workerctl
+package workerctl_test
 
 import (
 	"context"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/daichitakahashi/workerctl"
 )
 
 func TestJobRunner(t *testing.T) {
-	var runner JobRunner
+	var runner workerctl.JobRunner
 	var completed int32
 
 	runNum := int32(50)
@@ -31,7 +33,7 @@ func TestJobRunner(t *testing.T) {
 
 func TestJobRunner_Panic(t *testing.T) {
 	t.Run("without PanicHandler", func(t *testing.T) {
-		var runner JobRunner
+		var runner workerctl.JobRunner
 		defer func() {
 			rvr := recover()
 			if rvr == nil {
@@ -44,7 +46,7 @@ func TestJobRunner_Panic(t *testing.T) {
 	})
 
 	t.Run("without PanicHandler", func(t *testing.T) {
-		var runner JobRunner
+		var runner workerctl.JobRunner
 		defer func() {
 			rvr := recover()
 			if rvr != nil {

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,7 @@
 package workerctl
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"sync"
@@ -39,6 +40,24 @@ type Aborter struct {
 	mu     sync.Mutex
 	closed bool
 	err    error
+}
+
+type key int8
+
+const (
+	abortKey key = iota + 1
+)
+
+// WithAbort set Aborter to new Context based on ctx.
+// Call Abort with returned new Context, set Aborter's Abort is called.
+func WithAbort(ctx context.Context, a *Aborter) context.Context {
+	return context.WithValue(ctx, abortKey, a)
+}
+
+// Abort invoke Aborter.Abort set by using WithAbort.
+// Workers can signal abort if they know Controller's context.
+func Abort(ctx context.Context) {
+	ctx.Value(abortKey).(*Aborter).Abort()
 }
 
 func (a *Aborter) aborted() chan struct{} {

--- a/utils.go
+++ b/utils.go
@@ -1,7 +1,6 @@
 package workerctl
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"sync"
@@ -109,32 +108,4 @@ func (c Closer) CloseOnError(err error) error {
 		return multierr.Append(err, c.Close())
 	}
 	return nil
-}
-
-type transferCtx struct {
-	context.Context
-	values context.Context
-}
-
-// Transfer transfers holder's values to new context based on ctx.
-// It enables us to access attached values of holder via a new context.
-// Lifetime of new context is detached from lifetime of holder.
-func Transfer(ctx, holder context.Context) context.Context {
-	return &transferCtx{
-		Context: ctx,
-		values:  holder,
-	}
-}
-
-func (c *transferCtx) Value(key interface{}) interface{} {
-	v := c.values.Value(key)
-	if v != nil {
-		return v
-	}
-	return c.Context.Value(key)
-}
-
-// Transferred is a shorthand of Transfer(context.Background(), holder).
-func Transferred(holder context.Context) context.Context {
-	return Transfer(context.Background(), holder)
 }


### PR DESCRIPTION
Follow context.Context aware style.
```
Do not store Contexts inside a struct type; instead, pass a Context explicitly to each function that needs it.
```